### PR TITLE
feat: render tutor copy from markdown

### DIFF
--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -658,6 +658,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1475,7 @@ dependencies = [
  "jsonc-parser",
  "lexopt",
  "pretty_assertions",
+ "pulldown-cmark",
  "ratatui",
  "ratconfig",
  "serde",

--- a/rust_core/yazelix_core/Cargo.toml
+++ b/rust_core/yazelix_core/Cargo.toml
@@ -21,6 +21,7 @@ crossterm = "0.29"
 directories = "5.0.1"
 jsonc-parser = { version = "0.32.3", features = ["cst", "serde"] }
 lexopt = "0.3"
+pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm_0_29"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust_core/yazelix_core/src/cli_render.rs
+++ b/rust_core/yazelix_core/src/cli_render.rs
@@ -1,19 +1,40 @@
-use crossterm::style::Stylize;
+use crossterm::{
+    queue,
+    style::{Attribute, Color, Print, SetAttribute, SetForegroundColor},
+};
 use std::io::IsTerminal;
 
 pub fn colors_enabled() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
+    let term = std::env::var_os("TERM");
+    colors_enabled_from_inputs(
+        std::env::var_os("NO_COLOR").is_some(),
+        std::env::var_os("FORCE_COLOR").is_some(),
+        term.as_deref().and_then(std::ffi::OsStr::to_str),
+        std::io::stdout().is_terminal(),
+    )
+}
+
+fn colors_enabled_from_inputs(
+    no_color: bool,
+    force_color: bool,
+    term: Option<&str>,
+    stdout_is_terminal: bool,
+) -> bool {
+    if no_color {
         return false;
     }
-    if std::env::var_os("FORCE_COLOR").is_some() {
+    if force_color {
         return true;
     }
-    std::io::stdout().is_terminal()
+    if term == Some("dumb") {
+        return false;
+    }
+    stdout_is_terminal
 }
 
 pub fn section_title(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.yellow().bold())
+        styled(text, Color::Yellow, true)
     } else {
         text.to_string()
     }
@@ -21,7 +42,7 @@ pub fn section_title(text: &str, color: bool) -> String {
 
 pub fn label(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.dark_yellow())
+        styled(text, Color::DarkYellow, false)
     } else {
         text.to_string()
     }
@@ -29,7 +50,7 @@ pub fn label(text: &str, color: bool) -> String {
 
 pub fn accent(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.cyan().bold())
+        styled(text, Color::Cyan, true)
     } else {
         text.to_string()
     }
@@ -37,7 +58,15 @@ pub fn accent(text: &str, color: bool) -> String {
 
 pub fn muted(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.cyan())
+        styled(text, Color::Cyan, false)
+    } else {
+        text.to_string()
+    }
+}
+
+pub fn inline_code(text: &str, color: bool) -> String {
+    if color {
+        styled(text, Color::Magenta, true)
     } else {
         text.to_string()
     }
@@ -45,7 +74,7 @@ pub fn muted(text: &str, color: bool) -> String {
 
 pub fn success(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.green().bold())
+        styled(text, Color::Green, true)
     } else {
         text.to_string()
     }
@@ -53,8 +82,61 @@ pub fn success(text: &str, color: bool) -> String {
 
 pub fn warning(text: &str, color: bool) -> String {
     if color {
-        format!("{}", text.yellow().bold())
+        styled(text, Color::Yellow, true)
     } else {
         text.to_string()
+    }
+}
+
+fn styled(text: &str, foreground: Color, bold: bool) -> String {
+    crossterm::style::force_color_output(true);
+    let mut output = Vec::new();
+    if bold {
+        queue!(output, SetAttribute(Attribute::Bold)).expect("ANSI style writes to memory");
+    }
+    queue!(
+        output,
+        SetForegroundColor(foreground),
+        Print(text),
+        SetAttribute(Attribute::NormalIntensity),
+        SetForegroundColor(Color::Reset)
+    )
+    .expect("ANSI style writes to memory");
+    String::from_utf8(output).expect("ANSI style commands emit UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test lane: default
+    // Defends: the shared CLI color gate honors explicit plain-output environments before emitting ANSI.
+    #[test]
+    fn color_decision_honors_no_color_force_color_and_term_dumb() {
+        assert!(!colors_enabled_from_inputs(
+            true,
+            true,
+            Some("xterm-256color"),
+            true
+        ));
+        assert!(colors_enabled_from_inputs(false, true, Some("dumb"), false));
+        assert!(!colors_enabled_from_inputs(
+            false,
+            false,
+            Some("dumb"),
+            true
+        ));
+        assert!(colors_enabled_from_inputs(
+            false,
+            false,
+            Some("xterm-256color"),
+            true
+        ));
+        assert!(!colors_enabled_from_inputs(
+            false,
+            false,
+            Some("xterm-256color"),
+            false
+        ));
     }
 }

--- a/rust_core/yazelix_core/src/front_door_commands.rs
+++ b/rust_core/yazelix_core/src/front_door_commands.rs
@@ -10,9 +10,8 @@ use crate::front_door_render::{
 };
 use crate::require_runtime_component_enabled;
 use crate::session_facts::compute_session_facts_from_env;
-use crate::terminal_control;
+use crate::tutor_document;
 use crate::upgrade_summary::{RuntimeSnapshotContext, show_known_changes_since_installed_runtime};
-use crossterm::style::Color;
 use std::process::Command;
 use std::time::Duration;
 
@@ -57,6 +56,92 @@ const TUTOR_LESSONS: &[TutorLessonSpec] = &[
         summary: "Jump from Yazelix-specific guidance into the upstream editor and shell tutors",
     },
 ];
+
+const TUTOR_OVERVIEW_MARKDOWN: &str = r#"# Yazelix tutor
+
+Yazelix is a managed terminal workspace built around Zellij, Yazi, and Helix.
+
+The important unit is the current tab workspace root: managed actions use that directory unless a tool is doing something more specific.
+
+## Start here
+
+Need a session first? Launch with `yzx launch` or start in the current terminal with `yzx enter`.
+
+1. Start the guided flow with `yzx tutor begin`.
+2. See every short lesson with `yzx tutor list`.
+3. Learn the workspace-critical bindings with `yzx keys`.
+4. Use `yzx menu` for fuzzy command discovery (or `Alt+Shift+M` inside Yazelix) and `yzx doctor` when behavior looks wrong.
+
+## Mental model
+
+**Managed panes:** Yazelix treats the editor/sidebar flow as a coordinated workspace, not just a pile of unrelated panes.
+
+**Directory flow:** The current tab root drives new panes, popup commands, and workspace-aware actions.
+
+**Discoverability:** `yzx help` is the command reference, `yzx keys` is the keybinding surface, and `yzx tutor` is the guided overview.
+
+## Next steps
+
+**Helix tutor:** `yzx tutor hx`
+
+**Nushell tutor:** `yzx tutor nu`
+
+**Command reference:** `yzx help`
+
+**Project overview:** `README.md`
+"#;
+
+const WORKSPACE_LESSON_MARKDOWN: &str = r#"# Yazelix tutor: Workspace roots and managed panes
+
+Practice the current-tab workspace model, Yazi handoff, and fresh project tabs.
+
+## Learn
+
+Start Yazelix from the folder you want to work in. That folder becomes the current tab workspace root for new panes, popup commands, and managed editor/sidebar coordination.
+
+Opening a file from Yazi into the managed editor also moves that tab's workspace root to the file's directory.
+
+## Mini quest
+
+1. If this session is not in the folder you want, leave it and start again from that folder with `yzx enter`, or use `yzx launch --path <dir>`.
+2. Run `yzx keys` and find the workspace actions.
+3. Use the managed Yazi sidebar to open a file in the editor.
+
+Next lesson: `yzx tutor discovery`.
+"#;
+
+const DISCOVERY_LESSON_MARKDOWN: &str = r#"# Yazelix tutor: Command and key discovery
+
+Use the command palette, key tables, and doctor output without memorizing everything.
+
+## Learn
+
+Use command surfaces when you know what you want, and discovery surfaces when you do not.
+
+## Mini quest
+
+1. Run `yzx help` for the command reference.
+2. Run `yzx keys` for keybinding discovery.
+3. Run `yzx menu` for fuzzy command discovery, or press `Alt+Shift+M` inside Yazelix.
+4. Run `yzx doctor` when the current runtime or config feels wrong.
+
+Next lesson: `yzx tutor tool_tutors`.
+"#;
+
+const TOOL_TUTORS_LESSON_MARKDOWN: &str = r#"# Yazelix tutor: Helix and Nushell tutors
+
+Jump from Yazelix-specific guidance into the upstream editor and shell tutors.
+
+## Learn
+
+Yazelix owns the workspace integration. Helix and Nushell still have their own deep learning flows.
+
+## Mini quest
+
+1. Run `yzx tutor hx` to practice Helix inside the editor's own tutor.
+2. Run `yzx tutor nu` to practice Nushell in Nushell's own tutor.
+3. Return to `yzx tutor list` when you want the Yazelix workspace path again.
+"#;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TutorArgs {
@@ -304,91 +389,12 @@ fn print_whats_new_help() {
     println!("  yzx whats_new");
 }
 
-fn heading(text: &str) -> String {
-    terminal_control::styled_bold(text, Color::Cyan)
-}
-
-fn accent(text: &str) -> String {
-    terminal_control::styled_bold(text, Color::Yellow)
-}
-
 fn command_label(text: &str) -> String {
-    terminal_control::styled(text, Color::White)
+    tutor_document::render_code_label(text)
 }
 
 fn render_yazelix_tutor_overview() -> String {
-    let mut lines = Vec::new();
-    lines.push(heading("Yazelix tutor"));
-    lines.push(String::new());
-    lines.push(
-        "Yazelix is a managed terminal workspace built around Zellij, Yazi, and Helix.".to_string(),
-    );
-    lines.push("The important unit is the current tab workspace root: managed actions use that directory unless a tool is doing something more specific.".to_string());
-    lines.push(String::new());
-    lines.push(heading("Start here"));
-    lines.push(format!(
-        "Need a session first? Launch with {} or start in the current terminal with {}.",
-        command_label("yzx launch"),
-        command_label("yzx enter")
-    ));
-    lines.push(format!(
-        "1. Start the guided flow with {}.",
-        command_label("yzx tutor begin")
-    ));
-    lines.push(format!(
-        "2. See every short lesson with {}.",
-        command_label("yzx tutor list")
-    ));
-    lines.push(format!(
-        "3. Learn the workspace-critical bindings with {}.",
-        command_label("yzx keys")
-    ));
-    lines.push(format!(
-        "4. Use {} for fuzzy command discovery (or {} inside Yazelix) and {} when behavior looks wrong.",
-        command_label("yzx menu"),
-        command_label("Alt+Shift+M"),
-        command_label("yzx doctor")
-    ));
-    lines.push(String::new());
-    lines.push(heading("Mental model"));
-    lines.push(format!(
-        "{} Yazelix treats the editor/sidebar flow as a coordinated workspace, not just a pile of unrelated panes.",
-        accent("Managed panes:")
-    ));
-    lines.push(format!(
-        "{} The current tab root drives new panes, popup commands, and workspace-aware actions.",
-        accent("Directory flow:")
-    ));
-    lines.push(format!(
-        "{} {} is the command reference, {} is the keybinding surface, and {} is the guided overview.",
-        accent("Discoverability:"),
-        command_label("yzx help"),
-        command_label("yzx keys"),
-        command_label("yzx tutor")
-    ));
-    lines.push(String::new());
-    lines.push(heading("Next steps"));
-    lines.push(format!(
-        "{} {}",
-        accent("Helix tutor:"),
-        command_label("yzx tutor hx")
-    ));
-    lines.push(format!(
-        "{} {}",
-        accent("Nushell tutor:"),
-        command_label("yzx tutor nu")
-    ));
-    lines.push(format!(
-        "{} {}",
-        accent("Command reference:"),
-        command_label("yzx help")
-    ));
-    lines.push(format!(
-        "{} {}",
-        accent("Project overview:"),
-        command_label("README.md")
-    ));
-    format!("{}\n", lines.join("\n"))
+    render_tutor_markdown(TUTOR_OVERVIEW_MARKDOWN)
 }
 
 fn tutor_lesson_from_id(id: &str) -> Option<TutorLesson> {
@@ -400,34 +406,19 @@ fn tutor_lesson_from_id(id: &str) -> Option<TutorLesson> {
     }
 }
 
-fn tutor_lesson_spec(lesson: TutorLesson) -> &'static TutorLessonSpec {
-    let id = match lesson {
-        TutorLesson::Workspace => "workspace",
-        TutorLesson::Discovery => "discovery",
-        TutorLesson::ToolTutors => "tool_tutors",
-    };
-    TUTOR_LESSONS
-        .iter()
-        .find(|spec| spec.id == id)
-        .expect("lesson spec exists")
-}
-
 fn render_tutor_list() -> String {
-    let mut lines = Vec::new();
-    lines.push(heading("Yazelix tutor lessons"));
-    lines.push(String::new());
+    let mut markdown = String::from("# Yazelix tutor lessons\n\n");
     for (index, lesson) in TUTOR_LESSONS.iter().enumerate() {
-        lines.push(format!(
-            "{}. {} {}",
+        markdown.push_str(&format!(
+            "{}. `yzx tutor {}` {}  \n",
             index + 1,
-            command_label(&format!("yzx tutor {}", lesson.id)),
+            lesson.id,
             lesson.title
         ));
-        lines.push(format!("   {}", lesson.summary));
+        markdown.push_str(&format!("   {}\n", lesson.summary));
     }
-    lines.push(String::new());
-    lines.push(format!("Start with {}.", command_label("yzx tutor begin")));
-    format!("{}\n", lines.join("\n"))
+    markdown.push_str("\nStart with `yzx tutor begin`.\n");
+    render_tutor_markdown(&markdown)
 }
 
 fn render_tutor_lesson(lesson: TutorLesson) -> String {
@@ -438,94 +429,20 @@ fn render_tutor_lesson(lesson: TutorLesson) -> String {
     }
 }
 
-fn render_lesson_header(lesson: TutorLesson) -> Vec<String> {
-    let spec = tutor_lesson_spec(lesson);
-    vec![
-        heading(&format!("Yazelix tutor: {}", spec.title)),
-        String::new(),
-        spec.summary.to_string(),
-        String::new(),
-    ]
-}
-
 fn render_workspace_lesson() -> String {
-    let mut lines = render_lesson_header(TutorLesson::Workspace);
-    lines.push(heading("Learn"));
-    lines.push("Start Yazelix from the folder you want to work in. That folder becomes the current tab workspace root for new panes, popup commands, and managed editor/sidebar coordination.".to_string());
-    lines.push("Opening a file from Yazi into the managed editor also moves that tab's workspace root to the file's directory.".to_string());
-    lines.push(String::new());
-    lines.push(heading("Mini quest"));
-    lines.push(format!(
-        "1. If this session is not in the folder you want, leave it and start again from that folder with {}, or use {}.",
-        command_label("yzx enter"),
-        command_label("yzx launch --path <dir>")
-    ));
-    lines.push(format!(
-        "2. Run {} and find the workspace actions.",
-        command_label("yzx keys")
-    ));
-    lines.push("3. Use the managed Yazi sidebar to open a file in the editor.".to_string());
-    lines.push(String::new());
-    lines.push(format!(
-        "Next lesson: {}.",
-        command_label("yzx tutor discovery")
-    ));
-    format!("{}\n", lines.join("\n"))
+    render_tutor_markdown(WORKSPACE_LESSON_MARKDOWN)
 }
 
 fn render_discovery_lesson() -> String {
-    let mut lines = render_lesson_header(TutorLesson::Discovery);
-    lines.push(heading("Learn"));
-    lines.push(
-        "Use command surfaces when you know what you want, and discovery surfaces when you do not."
-            .to_string(),
-    );
-    lines.push(String::new());
-    lines.push(heading("Mini quest"));
-    lines.push(format!(
-        "1. Run {} for the command reference.",
-        command_label("yzx help")
-    ));
-    lines.push(format!(
-        "2. Run {} for keybinding discovery.",
-        command_label("yzx keys")
-    ));
-    lines.push(format!(
-        "3. Run {} for fuzzy command discovery, or press {} inside Yazelix.",
-        command_label("yzx menu"),
-        command_label("Alt+Shift+M")
-    ));
-    lines.push(format!(
-        "4. Run {} when the current runtime or config feels wrong.",
-        command_label("yzx doctor")
-    ));
-    lines.push(String::new());
-    lines.push(format!(
-        "Next lesson: {}.",
-        command_label("yzx tutor tool_tutors")
-    ));
-    format!("{}\n", lines.join("\n"))
+    render_tutor_markdown(DISCOVERY_LESSON_MARKDOWN)
 }
 
 fn render_tool_tutors_lesson() -> String {
-    let mut lines = render_lesson_header(TutorLesson::ToolTutors);
-    lines.push(heading("Learn"));
-    lines.push("Yazelix owns the workspace integration. Helix and Nushell still have their own deep learning flows.".to_string());
-    lines.push(String::new());
-    lines.push(heading("Mini quest"));
-    lines.push(format!(
-        "1. Run {} to practice Helix inside the editor's own tutor.",
-        command_label("yzx tutor hx")
-    ));
-    lines.push(format!(
-        "2. Run {} to practice Nushell in Nushell's own tutor.",
-        command_label("yzx tutor nu")
-    ));
-    lines.push(format!(
-        "3. Return to {} when you want the Yazelix workspace path again.",
-        command_label("yzx tutor list")
-    ));
-    format!("{}\n", lines.join("\n"))
+    render_tutor_markdown(TOOL_TUTORS_LESSON_MARKDOWN)
+}
+
+fn render_tutor_markdown(markdown: &str) -> String {
+    tutor_document::render_tutor_markdown(markdown).expect("bundled tutor Markdown is supported")
 }
 
 fn run_external_command(command: &str, args: &[&str], label: &str) -> Result<i32, CoreError> {
@@ -624,6 +541,21 @@ mod tests {
         assert!(lesson.contains("yzx launch --path <dir>"));
         assert!(lesson.contains("yzx keys"));
         assert!(!lesson.contains("yzx cwd"));
+    }
+
+    // Defends: every bundled tutor Markdown document stays inside the supported terminal-renderer subset.
+    #[test]
+    fn bundled_tutor_markdown_documents_render_without_panics() {
+        assert!(render_yazelix_tutor_overview().contains("Yazelix tutor"));
+        assert!(render_tutor_list().contains("yzx tutor tool_tutors"));
+        for lesson in [
+            TutorLesson::Workspace,
+            TutorLesson::Discovery,
+            TutorLesson::ToolTutors,
+        ] {
+            let output = render_tutor_lesson(lesson);
+            assert!(output.contains("Mini quest"));
+        }
     }
 
     // Defends: the Rust-owned `yzx screen` parser keeps the public one-style surface while reserving the welcome-only internal flags for startup callers.

--- a/rust_core/yazelix_core/src/lib.rs
+++ b/rust_core/yazelix_core/src/lib.rs
@@ -66,6 +66,7 @@ pub(crate) mod terminal_control;
 pub mod terminal_cursor_materialization;
 pub mod terminal_materialization;
 pub mod terminal_variant;
+pub(crate) mod tutor_document;
 pub mod update_commands;
 pub mod upgrade_summary;
 pub mod user_config_paths;

--- a/rust_core/yazelix_core/src/terminal_control.rs
+++ b/rust_core/yazelix_core/src/terminal_control.rs
@@ -25,20 +25,6 @@ pub(crate) fn styled(text: impl ToString, color: Color) -> String {
     })
 }
 
-pub(crate) fn styled_bold(text: impl ToString, color: Color) -> String {
-    command_string(|output| {
-        queue!(
-            output,
-            SetAttribute(Attribute::Bold),
-            SetForegroundColor(color),
-            Print(text.to_string()),
-            SetAttribute(Attribute::NormalIntensity),
-            SetForegroundColor(Color::Reset)
-        )?;
-        Ok(())
-    })
-}
-
 pub(crate) fn styled_dim(text: impl ToString, color: Color) -> String {
     command_string(|output| {
         queue!(

--- a/rust_core/yazelix_core/src/tutor_document.rs
+++ b/rust_core/yazelix_core/src/tutor_document.rs
@@ -1,0 +1,449 @@
+use crate::cli_render;
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TutorDoc {
+    blocks: Vec<TutorBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TutorBlock {
+    Heading {
+        level: u8,
+        spans: Vec<TutorSpan>,
+    },
+    Paragraph(Vec<TutorSpan>),
+    List {
+        start: Option<u64>,
+        items: Vec<Vec<TutorSpan>>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TutorSpan {
+    Text(String),
+    Code(String),
+    Emphasis(Vec<TutorSpan>),
+    Strong(Vec<TutorSpan>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineKind {
+    Emphasis,
+    Strong,
+}
+
+#[derive(Debug)]
+struct InlineFrame {
+    kind: InlineKind,
+    spans: Vec<TutorSpan>,
+}
+
+#[derive(Debug)]
+struct ListBuilder {
+    start: Option<u64>,
+    items: Vec<Vec<TutorSpan>>,
+}
+
+#[derive(Debug, Default)]
+struct TutorDocBuilder {
+    blocks: Vec<TutorBlock>,
+    heading: Option<(u8, Vec<TutorSpan>)>,
+    paragraph: Option<Vec<TutorSpan>>,
+    list: Option<ListBuilder>,
+    item: Option<Vec<TutorSpan>>,
+    inline_stack: Vec<InlineFrame>,
+}
+
+pub(crate) fn parse_tutor_markdown(markdown: &str) -> Result<TutorDoc, String> {
+    let parser = Parser::new_ext(markdown, Options::empty());
+    let mut builder = TutorDocBuilder::default();
+
+    for event in parser {
+        match event {
+            Event::Start(tag) => builder.start_tag(tag)?,
+            Event::End(tag) => builder.end_tag(tag)?,
+            Event::Text(text) => builder.push_span(TutorSpan::Text(text.to_string()))?,
+            Event::Code(code) => builder.push_span(TutorSpan::Code(code.to_string()))?,
+            Event::SoftBreak => builder.push_span(TutorSpan::Text(" ".into()))?,
+            Event::HardBreak => builder.push_span(TutorSpan::Text("\n".into()))?,
+            Event::Rule => {
+                return Err("horizontal rules are not supported in tutor Markdown".into());
+            }
+            Event::Html(_) | Event::InlineHtml(_) => {
+                return Err("HTML is not supported in tutor Markdown".into());
+            }
+            Event::FootnoteReference(_) => {
+                return Err("footnotes are not supported in tutor Markdown".into());
+            }
+            Event::TaskListMarker(_) => {
+                return Err("task lists are not supported in tutor Markdown".into());
+            }
+            Event::InlineMath(_) | Event::DisplayMath(_) => {
+                return Err("math is not supported in tutor Markdown".into());
+            }
+        }
+    }
+
+    if !builder.inline_stack.is_empty() {
+        return Err("unclosed inline span in tutor Markdown".into());
+    }
+    if builder.heading.is_some() || builder.paragraph.is_some() || builder.item.is_some() {
+        return Err("unclosed block in tutor Markdown".into());
+    }
+    if builder.list.is_some() {
+        return Err("unclosed list in tutor Markdown".into());
+    }
+
+    Ok(TutorDoc {
+        blocks: builder.blocks,
+    })
+}
+
+pub(crate) fn render_tutor_markdown(markdown: &str) -> Result<String, String> {
+    render_tutor_markdown_with_color(markdown, cli_render::colors_enabled())
+}
+
+pub(crate) fn render_code_label(code: &str) -> String {
+    render_code_span(code, cli_render::colors_enabled())
+}
+
+pub(crate) fn render_tutor_markdown_with_color(
+    markdown: &str,
+    color: bool,
+) -> Result<String, String> {
+    let doc = parse_tutor_markdown(markdown)?;
+    Ok(render_tutor_doc(&doc, color))
+}
+
+fn render_tutor_doc(doc: &TutorDoc, color: bool) -> String {
+    let mut output = String::new();
+    let mut previous_was_blank = true;
+
+    for block in &doc.blocks {
+        if !previous_was_blank {
+            output.push('\n');
+        }
+        match block {
+            TutorBlock::Heading { level, spans } => {
+                let text = render_spans(spans, color);
+                output.push_str(&render_heading(*level, &text, color));
+                output.push('\n');
+                previous_was_blank = false;
+            }
+            TutorBlock::Paragraph(spans) => {
+                output.push_str(&render_spans(spans, color));
+                output.push('\n');
+                previous_was_blank = false;
+            }
+            TutorBlock::List { start, items } => {
+                for (index, item) in items.iter().enumerate() {
+                    let marker = match start {
+                        Some(first) => {
+                            format!("{}. ", first + index as u64)
+                        }
+                        None => "- ".to_string(),
+                    };
+                    output.push_str(&render_list_item(&marker, item, color));
+                }
+                previous_was_blank = false;
+            }
+        }
+    }
+
+    output
+}
+
+fn render_list_item(marker: &str, item: &[TutorSpan], color: bool) -> String {
+    let rendered = render_spans(item, color);
+    let mut lines = rendered.lines();
+    let mut output = String::new();
+
+    output.push_str(marker);
+    output.push_str(lines.next().unwrap_or_default());
+    output.push('\n');
+
+    let continuation_indent = " ".repeat(marker.chars().count());
+    for line in lines {
+        output.push_str(&continuation_indent);
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    output
+}
+
+fn render_heading(level: u8, text: &str, color: bool) -> String {
+    if level == 1 {
+        cli_render::accent(text, color)
+    } else {
+        cli_render::section_title(text, color)
+    }
+}
+
+fn render_spans(spans: &[TutorSpan], color: bool) -> String {
+    let mut output = String::new();
+    for span in spans {
+        match span {
+            TutorSpan::Text(text) => output.push_str(text),
+            TutorSpan::Code(code) => {
+                output.push_str(&render_code_span(code, color));
+            }
+            TutorSpan::Emphasis(children) => {
+                output.push_str(&cli_render::muted(&render_spans(children, color), color));
+            }
+            TutorSpan::Strong(children) => {
+                output.push_str(&cli_render::label(&render_spans(children, color), color));
+            }
+        }
+    }
+    output
+}
+
+fn render_code_span(code: &str, color: bool) -> String {
+    if color {
+        cli_render::inline_code(code, true)
+    } else {
+        format!("`{code}`")
+    }
+}
+
+impl TutorDocBuilder {
+    fn start_tag(&mut self, tag: Tag<'_>) -> Result<(), String> {
+        match tag {
+            Tag::Paragraph => {
+                if self.paragraph.is_some() {
+                    return Err("nested paragraphs are not supported in tutor Markdown".into());
+                }
+                self.paragraph = Some(Vec::new());
+            }
+            Tag::Heading { level, .. } => {
+                if self.heading.is_some() {
+                    return Err("nested headings are not supported in tutor Markdown".into());
+                }
+                self.heading = Some((heading_level(level), Vec::new()));
+            }
+            Tag::List(start) => {
+                if self.list.is_some() {
+                    return Err("nested lists are not supported in tutor Markdown".into());
+                }
+                self.list = Some(ListBuilder {
+                    start,
+                    items: Vec::new(),
+                });
+            }
+            Tag::Item => {
+                if self.list.is_none() {
+                    return Err("list item outside list in tutor Markdown".into());
+                }
+                if self.item.is_some() {
+                    return Err("nested list items are not supported in tutor Markdown".into());
+                }
+                self.item = Some(Vec::new());
+            }
+            Tag::Emphasis => self.inline_stack.push(InlineFrame {
+                kind: InlineKind::Emphasis,
+                spans: Vec::new(),
+            }),
+            Tag::Strong => self.inline_stack.push(InlineFrame {
+                kind: InlineKind::Strong,
+                spans: Vec::new(),
+            }),
+            Tag::BlockQuote(_)
+            | Tag::CodeBlock(_)
+            | Tag::HtmlBlock
+            | Tag::Link { .. }
+            | Tag::Image { .. }
+            | Tag::FootnoteDefinition(_)
+            | Tag::DefinitionList
+            | Tag::DefinitionListTitle
+            | Tag::DefinitionListDefinition
+            | Tag::Table(_)
+            | Tag::TableHead
+            | Tag::TableRow
+            | Tag::TableCell
+            | Tag::Strikethrough
+            | Tag::Superscript
+            | Tag::Subscript
+            | Tag::MetadataBlock(_) => {
+                return Err(format!("unsupported tutor Markdown tag: {tag:?}"));
+            }
+        }
+        Ok(())
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) -> Result<(), String> {
+        match tag {
+            TagEnd::Paragraph => {
+                let paragraph = self
+                    .paragraph
+                    .take()
+                    .ok_or("paragraph end without paragraph start")?;
+                if let Some(item) = &mut self.item {
+                    if !item.is_empty() {
+                        item.push(TutorSpan::Text(" ".into()));
+                    }
+                    item.extend(paragraph);
+                } else {
+                    self.blocks.push(TutorBlock::Paragraph(paragraph));
+                }
+            }
+            TagEnd::Heading(_) => {
+                let (level, spans) = self
+                    .heading
+                    .take()
+                    .ok_or("heading end without heading start")?;
+                self.blocks.push(TutorBlock::Heading { level, spans });
+            }
+            TagEnd::List(_) => {
+                let list = self.list.take().ok_or("list end without list start")?;
+                self.blocks.push(TutorBlock::List {
+                    start: list.start,
+                    items: list.items,
+                });
+            }
+            TagEnd::Item => {
+                let item = self.item.take().ok_or("item end without item start")?;
+                let list = self.list.as_mut().ok_or("item end outside list")?;
+                list.items.push(item);
+            }
+            TagEnd::Emphasis => self.pop_inline(InlineKind::Emphasis)?,
+            TagEnd::Strong => self.pop_inline(InlineKind::Strong)?,
+            TagEnd::BlockQuote(_)
+            | TagEnd::CodeBlock
+            | TagEnd::HtmlBlock
+            | TagEnd::Link
+            | TagEnd::Image
+            | TagEnd::FootnoteDefinition
+            | TagEnd::DefinitionList
+            | TagEnd::DefinitionListTitle
+            | TagEnd::DefinitionListDefinition
+            | TagEnd::Table
+            | TagEnd::TableHead
+            | TagEnd::TableRow
+            | TagEnd::TableCell
+            | TagEnd::Strikethrough
+            | TagEnd::Superscript
+            | TagEnd::Subscript
+            | TagEnd::MetadataBlock(_) => {
+                return Err(format!("unsupported tutor Markdown end tag: {tag:?}"));
+            }
+        }
+        Ok(())
+    }
+
+    fn push_span(&mut self, span: TutorSpan) -> Result<(), String> {
+        if let Some(frame) = self.inline_stack.last_mut() {
+            frame.spans.push(span);
+        } else if let Some((_, spans)) = &mut self.heading {
+            spans.push(span);
+        } else if let Some(spans) = &mut self.paragraph {
+            spans.push(span);
+        } else if let Some(item) = &mut self.item {
+            item.push(span);
+        } else {
+            return Err("inline content outside supported tutor Markdown block".into());
+        }
+        Ok(())
+    }
+
+    fn pop_inline(&mut self, kind: InlineKind) -> Result<(), String> {
+        let frame = self
+            .inline_stack
+            .pop()
+            .ok_or("inline end without inline start")?;
+        if frame.kind != kind {
+            return Err("mismatched inline span in tutor Markdown".into());
+        }
+        let span = match kind {
+            InlineKind::Emphasis => TutorSpan::Emphasis(frame.spans),
+            InlineKind::Strong => TutorSpan::Strong(frame.spans),
+        };
+        self.push_span(span)?;
+        Ok(())
+    }
+}
+
+fn heading_level(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test lane: default
+    // Defends: tutor Markdown stays a small portable authoring subset instead of silently accepting website-only Markdown.
+    #[test]
+    fn rejects_unsupported_markdown_constructs() {
+        assert!(parse_tutor_markdown("<span>html</span>").is_err());
+        assert!(parse_tutor_markdown("> quoted\n").is_err());
+        assert!(parse_tutor_markdown("[link](https://example.com)").is_err());
+        assert!(parse_tutor_markdown("```sh\nyzx tutor\n```\n").is_err());
+    }
+
+    // Defends: inline code remains a readable command/keybinding anchor in plain output and does not require ANSI to be distinguishable.
+    #[test]
+    fn renders_inline_code_with_plain_markers() {
+        let output = render_tutor_markdown_with_color(
+            "Run `yzx tutor begin` then press `Alt+Shift+M`.",
+            false,
+        )
+        .unwrap();
+        assert_eq!(output, "Run `yzx tutor begin` then press `Alt+Shift+M`.\n");
+    }
+
+    // Defends: color output makes inline commands visually distinct instead of rendering them as ordinary prose.
+    #[test]
+    fn renders_inline_code_with_ansi_when_color_is_enabled() {
+        let output = render_tutor_markdown_with_color("Run `yzx tutor begin`.", true).unwrap();
+        assert!(output.contains("yzx tutor begin"));
+        assert!(!output.contains("`yzx tutor begin`"));
+        assert!(output.contains("\u{1b}["));
+    }
+
+    // Defends: inline commands have their own visual role and do not reuse section-heading styling.
+    #[test]
+    fn renders_inline_code_with_distinct_color_from_section_titles() {
+        let output = render_tutor_markdown_with_color("## Learn\n\nRun `yzx keys`.", true).unwrap();
+        let code = cli_render::inline_code("yzx keys", true);
+        let section = cli_render::section_title("yzx keys", true);
+        assert_ne!(code, section);
+        assert!(output.contains(&code));
+    }
+
+    // Defends: the tutor renderer keeps headings, paragraphs, and list ordering stable for the CLI surface.
+    #[test]
+    fn renders_headings_paragraphs_and_ordered_lists() {
+        let output = render_tutor_markdown_with_color(
+            "# Yazelix tutor\n\nStart here.\n\n1. Run `yzx enter`\n2. Run `yzx keys`\n",
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            output,
+            "Yazelix tutor\n\nStart here.\n\n1. Run `yzx enter`\n2. Run `yzx keys`\n"
+        );
+    }
+
+    // Defends: hard breaks in list items keep tutorial summaries scannable instead of flattening each lesson into one dense line.
+    #[test]
+    fn indents_list_item_hard_break_continuations() {
+        let output = render_tutor_markdown_with_color(
+            "1. `yzx tutor workspace` Workspace roots  \n   Practice the current tab root.\n",
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            output,
+            "1. `yzx tutor workspace` Workspace roots\n   Practice the current tab root.\n"
+        );
+    }
+}


### PR DESCRIPTION
Hi Lucca,

This is the first narrow implementation slice from #634.

It follows the Tutor document model direction we discussed:

```text
Markdown tutor copy
-> pulldown-cmark
-> small Yazelix-owned TutorDoc / TutorBlock / TutorSpan
-> stdout renderer
```

What changed:

- moved the current Yazelix tutor copy out of Rust `format!` chains and into Markdown-authored text
- added a deliberately small tutor Markdown subset: headings, paragraphs, lists, inline code, emphasis/strong, and breaks
- reject unsupported constructs such as HTML, links, blockquotes, code blocks, tables, math, and task lists instead of silently accepting them
- render inline code as a distinct visual role in color output, while keeping backticks in plain output
- keep `yzx tutor list` readable with indented continuation lines
- added tests for the parser/renderer and for all bundled tutor Markdown documents

I intentionally kept this PR limited to the rendering/authoring boundary. It does not rewrite the tutor content around sections, scopes, keybindings, escape hatches, or outcomes yet, and it does not touch the website direction.

I also recorded the dependency decision in the Beads entry for #634: `pulldown-cmark` is used only for parsing, with default features disabled; terminal rendering remains Yazelix-owned.

Now `yzx tutor` in no-color terminal (partially):
<img width="932" height="591" alt="image" src="https://github.com/user-attachments/assets/c5161b90-38cc-46c6-8b2b-04a27507eda4" />
while in colored:
<img width="921" height="588" alt="image" src="https://github.com/user-attachments/assets/a1fcc7c1-c79c-4df6-9b24-2309b63b9eec" />

Testing:

- `nix develop .#ci -c cargo fmt --all --manifest-path rust_core/Cargo.toml --check`
- `nix develop .#ci -c cargo test --manifest-path rust_core/Cargo.toml -p yazelix_core tutor_document::tests`
- `nix develop .#ci -c cargo test --manifest-path rust_core/Cargo.toml -p yazelix_core front_door_commands::tests`
- `nix develop .#ci -c cargo check --manifest-path rust_core/Cargo.toml -p yazelix_core --all-targets`
- `nix develop .#ci -c env -u NO_COLOR FORCE_COLOR=1 cargo run --quiet --manifest-path rust_core/Cargo.toml -p yazelix_core --bin yzx_control -- tutor list`
- `nix develop .#ci -c env NO_COLOR=1 cargo run --quiet --manifest-path rust_core/Cargo.toml -p yazelix_core --bin yzx_control -- tutor list`

Note: a full `cargo test -p yazelix_core` still hits the existing `start_yazelix_scrubs_gui_loader_env_before_control_handoff` runtime-surface integration failure in my environment. The focused tutor tests and `--all-targets` check pass.