### PR TITLE
Remove stale fenix override from yazelixCursors input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
     yazelixCursors = {
       url = "github:luccahuguet/yazelix-cursors";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.fenix.follows = "fenix";
     };
     yazelixZellijBar = {
       url = "github:luccahuguet/yazelix-zellij-bar";


### PR DESCRIPTION
## Summary

- Remove the stale `fenix` follow override from the `yazelixCursors` input.

## Why

`yazelix-cursors` no longer exposes a `fenix` input, so the parent override emits:

```text
warning: input 'yazelixCursors' has an override for a non-existent input 'fenix'
```

The cursor lock node already references only `nixpkgs`, so this removes the warning without changing the dependency graph or `flake.lock`.

## Validation

- `nix flake metadata --no-write-lock-file .`
- Exit status 0 with no warning or error lines
- Confirmed `flake.lock` remained unchanged
